### PR TITLE
Add properties to use Test Kitchen with Chef 19 Target Mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.renderFinalNewline": true,
+  "editor.renderFinalNewline": "on",
   "editor.renderWhitespace":"all",
   "editor.trimAutoWhitespace": true,
   "files.exclude": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.2.0
+
+- Fix disparity between TestKitchen SSH wait parameters and Train
+- Fix user passing via a `train_user` override parameters
+- Add call to generate an RFC099 credentials file
+
 ## Version 0.1.0
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ transport:
 
 Options `user`, `host` and `password` (for kitchen-ec2 and Windows instances) are set automatically.
 
+If you want to use `kitchen-ec2` with the `root` user however (as needed in Chef 19 Target Mode), you need to additionally specify `train_user: root`. This is due to a long-standing bug in Kitchen-EC2 where the standard platform's autodetected user will override manually specified `root` values.
+
+Standard and community-supported options for transports:
 - [AWS Session Manager Transport](https://github.com/tecracer-chef/train-awsssm/blob/master/lib/train-awsssm/transport.rb#L8-L14)
 - Docker Transport: no additional options
 - [Serial/USB Transport](https://github.com/tecracer-chef/train-serial/blob/master/lib/train-serial/transport.rb#L8-L22)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options `user`, `host` and `password` (for kitchen-ec2 and Windows instances) ar
 If you want to use `kitchen-ec2` with the `root` user however (as needed in Chef 19 Target Mode), you need to additionally specify `train_user: root`. This is due to a long-standing bug in Kitchen-EC2 where the standard platform's autodetected user will override manually specified `root` values.
 
 Standard and community-supported options for transports:
+
 - [AWS Session Manager Transport](https://github.com/tecracer-chef/train-awsssm/blob/master/lib/train-awsssm/transport.rb#L8-L14)
 - Docker Transport: no additional options
 - [Serial/USB Transport](https://github.com/tecracer-chef/train-serial/blob/master/lib/train-serial/transport.rb#L8-L22)

--- a/lib/kitchen-transport-train/version.rb
+++ b/lib/kitchen-transport-train/version.rb
@@ -1,3 +1,3 @@
 module KitchenTransportTrain
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/lib/kitchen/transport/train.rb
+++ b/lib/kitchen/transport/train.rb
@@ -59,7 +59,7 @@ module Kitchen
           # See https://github.com/test-kitchen/kitchen-ec2/pull/273
           config[:user] = config[:username] = @connection.transport_options[:train_user] || @connection.transport_options[:user]
 
-          require 'toml-rb' unless defined?(TomlRB)
+          require "toml-rb" unless defined?(TomlRB)
 
           "['#{instance_name}']\n" + TomlRB.dump(config)
         end

--- a/lib/kitchen/transport/train.rb
+++ b/lib/kitchen/transport/train.rb
@@ -39,6 +39,32 @@ module Kitchen
           yield self if block_given?
         end
 
+        def train_uri
+          @connection.uri
+        end
+
+        def credentials_file
+          instance_name = @connection.transport_options[:instance_name]
+
+          # TODO: only include non-default values
+          config = @backend.instance_variable_get(:@connection_options)
+          config.compact!
+          config.transform_values! { |v| v.is_a?(Symbol) ? v.to_s : v }
+
+          # TODO: huh! is there no clear "signature"? accepted, default parameters + dynamics?
+          config[:host] = config[:hostname] = @connection.transport_options[:host]
+          config[:user] = config[:username] = @connection.transport_options[:user]
+          config[:key_files] = @connection.transport_options[:key_files]
+
+          # TODO: I'm tired, so I do this the ugly way
+          config[:user] = config[:username] = "root"
+
+          # TODO: is this part of TK? or a new dependency of kitchen-transport-train?
+          require 'toml-rb' unless defined?(TomlRB)
+
+          "['#{instance_name}']\n" + TomlRB.dump(config)
+        end
+
         def execute(command)
           return if command.nil?
 


### PR DESCRIPTION
### Description

Add ability to create an RFC099 credentials file and override user properties. Needed to interface between Test Kitchen and Chef 19 Target Mode properties.
